### PR TITLE
Allow Laravel 13 (`^13.0`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php" : ">=7.1",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/session": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/session": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
## What

Add `^13.0` to `illuminate/support` and `illuminate/session` constraints in `composer.json`.

## Why

Used (transitively via `padosoftcms/padosoftcms-admin`) by [gescat-laravel](https://github.com/padosoft/gescat-laravel) on branch `shift-174733` (upgrade Laravel 12 → 13).

## Compatibility

Additive only — no breaking changes. The `|^13.0` is appended after the existing range.

## Patch

See [12eb046](https://github.com/luca9692/laravel-notifier/commit/12eb04613c2635383abc13bbe630e4ff82dbe0a2) — 2 lines changed.